### PR TITLE
multiplatform devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
 	"name": "everest-dev",
-	"build": {
-		// Path is relative to the devcontainer.json file.
-		"dockerfile": "Dockerfile"
-	},
+	"image": "ghcr.io/voltpost/everest-devcontainer:latest",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup containerd
+        uses: crazy-max/ghaction-setup-containerd@v3.0.0
+
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_devcontainer:
-    runs-on: macos-14
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   build:
     # depends on docker build
     needs: build_devcontainer
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/voltpost/everest-devcontainer
       credentials:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{matrix.os}}
     container:
       image: ghcr.io/voltpost/everest-devcontainer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,13 @@ env:
 jobs:
   build_devcontainer:
     runs-on: ubuntu-latest
+
+    env:
+      # Work around skopeo issue in ubuntu 22.
+      # https://github.com/containers/skopeo/issues/1874#issuecomment-1541088511
+      # https://github.com/devcontainers/ci/issues/191#issuecomment-1973786876
+      BUILDX_NO_DEFAULT_ATTESTATIONS: true
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,10 @@ jobs:
   build:
     # depends on docker build
     needs: build_devcontainer
-    runs-on: [ubuntu-latest, macos-latest]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.os}}
     container:
       image: ghcr.io/voltpost/everest-devcontainer
       credentials:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,7 @@ jobs:
     # depends on docker build
     needs: build_devcontainer
     continue-on-error: true
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-13]
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/voltpost/everest-devcontainer
       credentials:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ env:
 jobs:
   build_devcontainer:
     runs-on: ubuntu-latest
-
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +37,7 @@ jobs:
   build:
     # depends on docker build
     needs: build_devcontainer
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     container:
       image: ghcr.io/voltpost/everest-devcontainer
       credentials:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ env:
 jobs:
   build_devcontainer:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_DEFAULT_PLATFORM: linux/amd64,linux/arm64
     steps:
       - uses: actions/checkout@v4
 
@@ -35,6 +33,7 @@ jobs:
         with:
           imageName: ${{env.DEVCONTAINER_IMAGE}}
           cacheFrom: ${{env.DEVCONTAINER_IMAGE}}
+          platform: linux/amd64,linux/arm64
           push: always
 
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
   build:
     # depends on docker build
     needs: build_devcontainer
+    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build_devcontainer:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
   build:
     # depends on docker build
     needs: build_devcontainer
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     container:
       image: ghcr.io/voltpost/everest-devcontainer
       credentials:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup containerd
-        uses: crazy-max/ghaction-setup-containerd@v3.0.0
+      - name: Set up QEMU for multi-architecture builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx for multi-architecture builds
+        uses: docker/setup-buildx-action@v3
+        with:
+          use: true
 
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
-Approximate the EVerest [Kind-of Quickstart](https://everest.github.io/nightly/general/03_quick_start_guide.html).
+Approximate the EVerest [Quickstart](https://everest.github.io/nightly/general/03_quick_start_guide.html).
 
+## Actions workflow
 - Build the devcontainer so we can run the build inside it.
 - Run `edm init`.
 - Run CMake.
 - Run Ninja.
+
+## Running the devcontainer locally
+First you must have a GitHub personal access token. Then you can use the token as a password to log into GitHub Container registry.
+```shell
+docker login ghcr.io -p $token
+```
+Then you will have access to the image built by CI in this repo.
+```shell
+docker pull ghcr.io/voltpost/everest-devcontainer
+```
+You should now be able to use this container in VSCode or with the [devcontainer cli](https://github.com/devcontainers/cli).
+```shell
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . bash
+```


### PR DESCRIPTION
Build the devcontainer for both amd64 and arm64. Note that the arm image won't run in actions because of lack of compatible runners, but you can fetch it and use it locally.

Fixes #1.